### PR TITLE
Limited walks return empty

### DIFF
--- a/lib/fraggle/client.rb
+++ b/lib/fraggle/client.rb
@@ -121,8 +121,10 @@ module Fraggle
     end
 
     def all(m, rev, path, off, lim, ents=[], &blk)
+      # We're decrementing lim as we go, so we need to return
+      # the accumulated values
       if lim == 0
-        cn.next_tick { blk.call([], nil) }
+        cn.next_tick { blk.call(ents, nil) }
         return
       end
 


### PR DESCRIPTION
I didn't see a high level test case that I could add a regression spec to.  Assuming @c is a fibered-out wrapper around a fraggle client, the last line of this test case fails with 0 != 1.

```
rev = @c.rev
@c.set(rev, "/a/b", "hi")
@c.set(rev, "/a/c", "bye")

@c.getdir(@c.rev, "/a").size.should == 2
@c.getdir(@c.rev, "/a", 0, 1).size.should == 1
```
