### PR TITLE
Do not remove the first address when connecting for the first time

### DIFF
--- a/lib/fraggle.rb
+++ b/lib/fraggle.rb
@@ -21,7 +21,7 @@ module Fraggle
       raise ArgumentError, "there were no addrs supplied in the uri (#{uri.inspect})"
     end
 
-    addr = addrs.shift
+    addr = addrs.slice(rand(addrs.length))
     host, port = addr.split(":")
 
     cn = EM.connect(host, port, Connection, addr)

--- a/test/fraggle_connection_receive_data.rb
+++ b/test/fraggle_connection_receive_data.rb
@@ -1,0 +1,38 @@
+
+require 'rspec'
+require 'fraggle/connection'
+
+class TestConnection
+ include Fraggle::Connection
+ def initialize
+ end 
+end
+
+describe Fraggle::Connection, '#receive_data' do
+  it "should receive data and call received_data (one packet)" do
+    msg = "abc123" * 1000
+    buf = [msg.size].pack("N") + msg
+    res = "done"
+    Fraggle::Response.should_receive(:decode).with(msg).and_return(res)
+    conn = TestConnection.new
+    conn.should_receive(:receive_response).with(res).and_return
+    conn.receive_data(buf)
+  end
+  it "should receive data and call received_data when split across two chunks" do
+    msg = "abc" * 100
+    buf = [msg.size].pack("N") + msg
+    chunks = [
+      buf[0..99],
+      buf[100..199],
+      buf[200..-1]
+    ]
+    res = "done"
+    Fraggle::Response.should_receive(:decode).with(msg).and_return(res)
+    conn = TestConnection.new
+    conn.should_receive(:receive_response).with(res).and_return
+    chunks.each do |chunk|
+      conn.receive_data(chunk)
+    end
+  end
+end
+


### PR DESCRIPTION
If doozerd is still coming up it will only reconnect to the remaining addresses in the list. None of the other addrs get removed so why remove the first one?
